### PR TITLE
added basePath and assetPrefix to next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,5 +15,7 @@ module.exports = withCSS({
       "viloxyf_z2GW6K4CT-KQD_MoLEA2wqv5jWuq4Jd0P7ymgG5GJGMpvMneXZzhK3sL",
     GOOGLE_CLIENT_ID: 
       process.env.GOOGLE_CLIENT_ID
-  }
+  },
+  basePath: "/coderssb-website",
+  assetPrefix: "/coderssb-website"
 });


### PR DESCRIPTION
When deployed as a project site, the website will be hosted on the subdomain https://coders-sb.github.io/coderssb-website/ instead of https://coders-sb.github.io/. This breaks internal links and paths for images and CSS stylesheets. Adding "/coderssb-website" as the basePath and assetPrefix fixes this.